### PR TITLE
expose asTransport

### DIFF
--- a/Sound/SC3/Server/State/Monad.hs
+++ b/Sound/SC3/Server/State/Monad.hs
@@ -29,6 +29,7 @@ module Sound.SC3.Server.State.Monad (
 , SyncIdAllocator
 , sync
 , unsafeSync
+, asTransport
 -- * Concurrency
 , fork
 ) where


### PR DESCRIPTION
I'd like to be able to use things like `play` from hsc3 in the Server monad.
